### PR TITLE
Add HTTPS option and cleanup elastic CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ In the case of local install, the script will be available through `~/.local/bin
 
 `elastic 'foo:bar' --source 'otherfield' | jq .`
 
+HTTPS endpoints are supported. Use `--insecure` to skip TLS certificate
+verification if needed.
+
 ## License ##
 
 (The MIT License)

--- a/bin/elastic
+++ b/bin/elastic
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import sys, re, os, re, json, ssl
-import certifi
 import argparse
 import configparser
+import json
+import os
+import re
+import sys
+
+import certifi
 from elasticsearch import Elasticsearch
 from elasticsearch import helpers
 
@@ -41,11 +45,19 @@ def load_args():
   parser.add_argument('--doctype', dest='doc_type', type=str, help='Document type to query for, default: all', default=elastic_doc_type)
   parser.add_argument('--order', dest='order', action='store_true', help='Elastic scroll "keep_order", default: false', default=False)
   parser.add_argument('--source', dest='source', help='Comma separated list of fields, default: all', type=lambda x: x.split(','))
+  parser.add_argument('--insecure', dest='insecure', action='store_true',
+                      help='Disable TLS certificate verification')
   return parser.parse_args()
 
 def main():
   args = load_args()
-  es = Elasticsearch([args.url], ca_certs=certifi.where, verify_certs=False, request_timeout=30)
+  verify = not args.insecure
+  es = Elasticsearch(
+    [args.url],
+    ca_certs=certifi.where(),
+    verify_certs=verify,
+    request_timeout=30,
+  )
   results = helpers.scan(es,
     index=args.index,
     doc_type=args.doc_type,


### PR DESCRIPTION
## Summary
- tidy imports in CLI script
- add `--insecure` option to toggle TLS verification
- enable HTTPS certificate verification by default
- document HTTPS usage in README

## Testing
- `python3 -m py_compile bin/elastic`